### PR TITLE
Add AI Insights dashboard widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ To get LifeLog up and running, follow these general steps:
         lifelog setup-test-data
         ```
     *   This copies `tests/testdata/2025-05-22.parquet` and a small summary file into `LifeLog/storage/curated/timeline/` and `LifeLog/storage/summary/daily/`.
-    *   The customizable dashboard includes a quick link to this date so you can explore the interface immediately.
+    *   The customizable dashboard includes a quick link to this date so you can explore the interface immediately. You can toggle widgets such as Quick Links, Daily Summary, AI Insights, Stats, and more.
 
 8.  **Run Backend Server:**
     *   Navigate to the `backend` directory (if not already there for pip install).

--- a/frontend/src/components/dashboard/AIInsightsWidget.tsx
+++ b/frontend/src/components/dashboard/AIInsightsWidget.tsx
@@ -1,0 +1,29 @@
+import AIInsights from '../AIInsights';
+import { useDayData } from '../../hooks/useDayData';
+
+export default function AIInsightsWidget() {
+  const { data, loading, error } = useDayData('2025-05-22');
+
+  if (loading) {
+    return (
+      <section className="border-card bg-secondary p-4 shadow-card">
+        <p className="text-secondary">Loading insights...</p>
+      </section>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <section className="border-card bg-secondary p-4 shadow-card">
+        <p className="text-secondary">Failed to load insights.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="border-card bg-secondary p-4 shadow-card" aria-label="AI insights">
+      <h2 className="text-lg font-semibold mb-2 text-primary">AI Insights</h2>
+      <AIInsights summary={data.summary} entries={data.entries} />
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/index.ts
+++ b/frontend/src/components/dashboard/index.ts
@@ -3,3 +3,4 @@ export { default as DailySummaryWidget } from "./DailySummaryWidget";
 export { default as ThemeWidget } from "./ThemeWidget";
 export { default as StatsWidget } from "./StatsWidget";
 export { default as RecentDaysWidget } from "./RecentDaysWidget";
+export { default as AIInsightsWidget } from "./AIInsightsWidget";

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -5,6 +5,7 @@ import {
   ThemeWidget,
   StatsWidget,
   RecentDaysWidget,
+  AIInsightsWidget,
 } from "../components/dashboard";
 
 interface WidgetDef {
@@ -23,6 +24,7 @@ const AVAILABLE_WIDGETS: WidgetDef[] = [
   { key: "stats", label: "Daily Stats", element: <StatsWidget /> },
   { key: "recent", label: "Recent Days", element: <RecentDaysWidget /> },
   { key: "theme", label: "Theme Switcher", element: <ThemeWidget /> },
+  { key: "insights", label: "AI Insights", element: <AIInsightsWidget /> },
 ];
 
 export default function Home() {


### PR DESCRIPTION
## 🎯 Purpose
Enhance the dashboard by introducing an "AI Insights" widget and updating documentation.

## 🔧 Changes Made
- Added new `AIInsightsWidget` and exported it in the dashboard index
- Updated dashboard page to include the widget and allow customization
- Documented available widgets in README

## 🧪 Testing
- ✅ `pytest -q`
- ✅ `python -m py_compile` on all Python files
- ✅ `npm run build`
- ✅ `npm run lint`
- ❌ `mypy LifeLog/` *(interrupted; environment timeout)*

------
https://chatgpt.com/codex/tasks/task_e_684383ccd49483208c03b8f7374e84f4